### PR TITLE
Updated spotify resolver for api v9

### DIFF
--- a/spotify/callbacks.h
+++ b/spotify/callbacks.h
@@ -58,7 +58,6 @@ static void SP_CALLCONV loggedIn(sp_session *session, sp_error error)
     switch (error) {
         case SP_ERROR_BAD_API_VERSION:
         case SP_ERROR_API_INITIALIZATION_FAILED:
-        case SP_ERROR_RESOURCE_NOT_LOADED:
         case SP_ERROR_BAD_APPLICATION_KEY:
         case SP_ERROR_CLIENT_TOO_OLD:
         case SP_ERROR_BAD_USER_AGENT:

--- a/spotify/spotifyresolver.cpp
+++ b/spotify/spotifyresolver.cpp
@@ -518,7 +518,7 @@ void SpotifyResolver::login()
 {
     if( !m_username.isEmpty() && !m_pw.isEmpty() ) { // log in
         qDebug() << "Logging in with username:" << m_username;
-        sp_session_login(m_session, m_username.toLatin1(),  m_pw.toLatin1());
+        sp_session_login(m_session, m_username.toLatin1(),  m_pw.toLatin1(), false);
     }
 }
 


### PR DESCRIPTION
There's some new functions in the api, where one is "remember me". This one has to be bool in the login call and it's set to false in this case, and I'm not sure its needed for tomahawk (?)
