### PR TITLE
Fix valgrind warnings: Do not store char* from temporary QByteArrays.

### DIFF
--- a/spotify/spotifyresolver.cpp
+++ b/spotify/spotifyresolver.cpp
@@ -119,9 +119,9 @@ void SpotifyResolver::setup()
 
     // sessionConfig
     sessionConfig config;
-    config.cache_location = storagePath.constData();
-    config.settings_location = configPath.constData();
-    config.application_key = m_apiKey.constData();
+    config.cache_location = storagePath;
+    config.settings_location = configPath;
+    config.application_key = m_apiKey;
     config.application_key_size = m_apiKey.size();
     config.user_agent = "tomahawkresolver";
     config.tracefile = tracePath.toUtf8();

--- a/spotify/spotifysession.cpp
+++ b/spotify/spotifysession.cpp
@@ -58,7 +58,7 @@ SpotifySession::SpotifySession( sessionConfig config, QObject *parent )
     connect( this, SIGNAL( notifyMainThreadSignal() ), this, SLOT( notifyMainThread() ), Qt::QueuedConnection );
 
 
-    if(config.application_key != NULL ){
+    if(!config.application_key.isEmpty()) {
 
         m_config.api_version = SPOTIFY_API_VERSION;
         m_config.cache_location = config.cache_location;

--- a/spotify/spotifysession.h
+++ b/spotify/spotifysession.h
@@ -36,12 +36,12 @@
 **/
 typedef struct
 {
-    const char* cache_location;
-    const char* settings_location;
-    const char* user_agent;
-    const char* tracefile;
-    const char* device_id;
-    const void* application_key;
+    QByteArray cache_location;
+    QByteArray settings_location;
+    QByteArray user_agent;
+    QByteArray tracefile;
+    QByteArray device_id;
+    QByteArray application_key;
     size_t application_key_size;
 
 


### PR DESCRIPTION
The data becomes invalid when the QByteArray is destroyed.
