### PR TITLE
API fix for beets script collection

### DIFF
--- a/beets/content/contents/code/beets-resolver.js
+++ b/beets/content/contents/code/beets-resolver.js
@@ -140,7 +140,7 @@ var BeetsResolver = Tomahawk.extend(TomahawkResolver, {
     },
 
     albums: function (qid, artist) {
-        var url = this.baseUrl() + '/album/artist/' + encodeURIComponent(artist);
+        var url = this.baseUrl() + '/album/query/albumartist:' + encodeURIComponent(artist);
         Tomahawk.asyncRequest(url, function (xhr) {
             var response = JSON.parse(xhr.responseText),
                 results = [];


### PR DESCRIPTION
@xhochy kindly added some new API support for the beets script collection to the beets web service and built support into the resolver. I opted to change the API in a slightly different way than originally proposed. This small change makes the resolver compatible with my version of the change.

Change to beets is [here](https://github.com/sampsyo/beets/commit/70b528ed817783436e6331ff7f347fcd941fc29f).
