### PR TITLE
Fixes bug where Beets didn't return any results

### DIFF
--- a/beets/content/contents/code/beets.js
+++ b/beets/content/contents/code/beets.js
@@ -59,7 +59,11 @@ var BeetsResolver = Tomahawk.extend(TomahawkResolver, {
 
     // Resolution.
     resolve: function (qid, artist, album, title) {
-        this.beetsQuery(qid, ['artist:' + artist, 'album:' + album, 'title:' + title]);
+        if (album == '') {
+            this.beetsQuery(qid, ['artist:' + artist, 'title:' + title]);
+        } else {
+            this.beetsQuery(qid, ['artist:' + artist, 'album:' + album, 'title:' + title]);
+        }
     },
 
     search: function (qid, searchString) {


### PR DESCRIPTION
Beets' web plugin requires you to omit the 'album' part of a query if an album is empty; otherwise, it will search for tracks that aren't on any album at all (which is not the desired result).

This small patch fixes this bug. 
