### PR TITLE
URL-encode passwords for Google Music

### DIFF
--- a/gmusic/content/contents/code/gmusic.js
+++ b/gmusic/content/contents/code/gmusic.js
@@ -648,8 +648,8 @@ var GMusicResolver = Tomahawk.extend( TomahawkResolver, {
             }, {
                 method: 'POST',
                 data: "accountType=HOSTED_OR_GOOGLE&Email=" + that._email.trim()
-                    + "&Passwd=" + that._password.trim() + "&service=sj&source=tomahawk-gmusic-"
-                    + that._version,
+                    + "&Passwd=" + encodeURIComponent(that._password.trim()) 
+                    + "&service=sj&source=tomahawk-gmusic-" + that._version,
                 errorHandler: function (request) {
                     Tomahawk.log(name + " login failed:\n"
                         + request.status + " "


### PR DESCRIPTION
Passwords may contain special characters that need to be URL-encoded before being sent to the server. Probably causing the issue on Android where some accounts can't use the Google Play Music resolver, although why they would work fine on desktop is a mystery.

Has not actually been tested; I'm not sure that Tomahawk implements the `encodeURIComponent()` function.