### PR TITLE
[Tidal] Filter out any songs which are not available to stream.

### DIFF
--- a/tidal/content/contents/code/tidal.js
+++ b/tidal/content/contents/code/tidal.js
@@ -91,6 +91,12 @@ var TidalResolver = Tomahawk.extend( Tomahawk.Resolver.Promise, {
         return this._login(config);
     },
 
+    _convertTracks: function (entries) {
+        return entries.filter(function (entry) {
+            return entry.allowStreaming;
+        }).map(this._convertTrack, this);
+    },
+
     _convertTrack: function (entry) {
         return {
             artist:     entry.artist.name,
@@ -160,7 +166,7 @@ var TidalResolver = Tomahawk.extend( Tomahawk.Resolver.Promise, {
         return Tomahawk.get(this.api_location + "search/tracks", {
             data: params
         }).then( function (response) {
-            return response.items.map(that._convertTrack, that);
+            return that._convertTracks(response.items);
         });
     },
 
@@ -262,7 +268,7 @@ var TidalResolver = Tomahawk.extend( Tomahawk.Resolver.Promise, {
 
             return Promise.all([getInfo, getTracks]).then(function (response) {
                 var result = that._convertAlbum(response[0]);
-                result.tracks = response[1].items.map(that._convertTrack, that);
+                result.tracks = that._convertTracks(response[1].items);
                 return result;
             });
 
@@ -292,7 +298,7 @@ var TidalResolver = Tomahawk.extend( Tomahawk.Resolver.Promise, {
 
             return Promise.all([getInfo, getTracks]).then( function (response) {
                 var result = that._convertPlaylist(response[0]);
-                result.tracks = response[1].items.map(that._convertTrack, that);
+                result.tracks = that._convertTracks(response[1].items);
                 return result;
             });
         }


### PR DESCRIPTION
Because Tomahawk playback completely stops.

I tested with Flying Lotus' album "Until The Quiet Comes" which is in the Tidal database, and is returned in queries, but is not available to stream (could be a country-specific thing for that album).

`entry.streamReady seems to be equivalent.`