### PR TITLE
[Tidal] API has moved to a different URL.

### DIFF
--- a/tidal/content/contents/code/tidal.js
+++ b/tidal/content/contents/code/tidal.js
@@ -16,7 +16,7 @@ var TidalResolver = Tomahawk.extend( Tomahawk.Resolver.Promise, {
     apiVersion: 0.9,
 
     /* This can also be used with WiMP service if you change next 2 lines */
-    api_location : 'https://listen.tidalhifi.com/v1/',
+    api_location : 'https://api.tidalhifi.com/v1/',
     api_token : 'P5Xbeo5LFvESeDy6',
 
     logged_in: null, // null, = not yet tried, 0 = pending, 1 = success, 2 = failed


### PR DESCRIPTION
Not sure if I am meant to bump the version on this resolver? Since I don't think it's in the synchotron thingy?