### PR TITLE
[netease]Fix invalid m1 server to m5

### DIFF
--- a/netease/content/contents/code/netease.js
+++ b/netease/content/contents/code/netease.js
@@ -97,7 +97,7 @@ var NeteaseResolver = Tomahawk.extend( api_to_extend, {
             var format = that.strQuality[that._quality];
             var dfsid = result.songs[0][format].dfsId.toString();
             var ext   =  result.songs[0][format].extension;
-            var url = 'http://m1.music.126.net/' + that._encrypt(dfsid) + '/' +
+            var url = 'http://m5.music.126.net/' + that._encrypt(dfsid) + '/' +
                 dfsid + '.' + ext;
             if(newAPI)
                 return {url:url};


### PR DESCRIPTION
m1.music.126.net returns 404 error, while m5 still works