### PR TITLE
encode pleer url artist and track

### DIFF
--- a/prostopleer/content/contents/code/pleer.js
+++ b/prostopleer/content/contents/code/pleer.js
@@ -41,7 +41,7 @@ var ProstopleerResolver = Tomahawk.extend( Tomahawk.Resolver, {
     },
 
     resolve: function (params) {
-        var query = [ params.artist, params.track ].join(' - ');
+        var query = [ encodeURIComponent(params.artist), encodeURIComponent(params.track) ].join(' - ');
         return this.search({query:query});
     }
 });


### PR DESCRIPTION
When searching with enencoded artist name and track pleer.com doesn't return anything (for example when searching in russian)