### PR TITLE
[netease] Fixes DNS issue and when it adds a link to a blank track url

### DIFF
--- a/netease/content/contents/code/netease.js
+++ b/netease/content/contents/code/netease.js
@@ -98,7 +98,7 @@ var NeteaseResolver = Tomahawk.extend( Tomahawk.Resolver, {
             var ext   =  song[format].extension;
             // m2.music.126.net is also working but is properly resolvable via
             // chinese DNS servers only, thus m5
-            var url = 'http://222.23.55.116/m2.music.126.net/' + that._encrypt(dfsid) + '/' +
+            var url = 'http://p2.music.126.net/' + that._encrypt(dfsid) + '/' +
                 dfsid + '.' + ext;
             return {url:url};
         });

--- a/netease/content/contents/code/netease.js
+++ b/netease/content/contents/code/netease.js
@@ -92,7 +92,7 @@ var NeteaseResolver = Tomahawk.extend( Tomahawk.Resolver, {
             }
             if (!song[format])
             {
-                return {url:null};
+                return;
             }
             var dfsid = song[format].dfsId.toString();
             var ext   =  song[format].extension;

--- a/netease/content/metadata.json
+++ b/netease/content/metadata.json
@@ -3,7 +3,7 @@
     "pluginName": "netease",
     "author": "Anton Romanov",
     "email": "",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "website": "http://gettomahawk.com",
     "description": "Streams music from http://music.163.com",
     "type": "resolver/javascript",

--- a/netease/content/metadata.json
+++ b/netease/content/metadata.json
@@ -3,7 +3,7 @@
     "pluginName": "netease",
     "author": "Anton Romanov",
     "email": "",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "website": "http://gettomahawk.com",
     "description": "Streams music from http://music.163.com",
     "type": "resolver/javascript",


### PR DESCRIPTION
This fixes issue where the old m2.music.126.net dns started responding wrong. I think they move up a alphabet letter every now and then.

And:
When it responds with a blank quality and then includes a url to a null track.