### PR TITLE
[gmusic] Allow a person under trial to stream from the catalogue

### DIFF
--- a/gmusic/content/contents/code/gmusic.js
+++ b/gmusic/content/contents/code/gmusic.js
@@ -457,7 +457,7 @@ var GMusicResolver = Tomahawk.extend(Tomahawk.Resolver, {
                 throw new Error("Wasn't able to get resolver settings");
             }
 
-            that._allAccess = response.settings.entitlementInfo.isSubscription;
+            that._allAccess = response.settings.entitlementInfo.isSubscription || response.settings.entitlementInfo.isTrial;
             Tomahawk.log("Google Play Music All Access is "
                 + (that._allAccess ? "enabled" : "disabled" )
             );


### PR DESCRIPTION
Hi,
As isSubcription isn't showing up if a person is under a trial (i.e. the 90 day one that is currently up) it won't allow the user to stream from the GMusic catalogue. This fixes that.