### PR TITLE
Fixed issue with not being able to login to Tidal.

### DIFF
--- a/tidal/content/contents/code/tidal.js
+++ b/tidal/content/contents/code/tidal.js
@@ -18,6 +18,7 @@ var TidalResolver = Tomahawk.extend(Tomahawk.Resolver, {
     /* This can also be used with WiMP service if you change next 2 lines */
     api_location: 'https://listen.tidal.com/v1/',
     api_token: 'P5Xbeo5LFvESeDy6',
+    api_clientVer: '2.2.1--7',
 
     logged_in: null, // null, = not yet tried, 0 = pending, 1 = success, 2 = failed
 
@@ -403,7 +404,8 @@ var TidalResolver = Tomahawk.extend(Tomahawk.Resolver, {
             type: 'POST', // backwards compatibility for old versions of tomahawk.js
             data: {
                 "username": config.email.trim(),
-                "password": config.password.trim()
+                "password": config.password.trim(),
+                "clientVersion": TidalResolver.api_clientVer //clientVersion string, API now checks for this on login
             },
             headers: {'Origin': 'http://listen.tidal.com'}
         };


### PR DESCRIPTION
The Tidal API now checks for a "clientVersion" string when processing logins, if the clientVersion is not included in the request the API will generate a 403 and not return a response back to the user. Added the current version at the time of writing (2.2.1--7). Not sure if the actual version number matters but if it does it may be possible to query the API for the current version and it might be worth the time to research this.